### PR TITLE
Remove dub.sh domain redirects

### DIFF
--- a/.github/old_README.md
+++ b/.github/old_README.md
@@ -6,13 +6,13 @@ _Winner of [Obsidian October](http://obsidian.md/october2021) 2021's Best Theme 
 
 > Primary is soft, chewy, comforting — like a chocolate chip cookie, or a warm brownie. Primary instantly puts you in a relaxed state that opens the door to creativity and exploration. Wonderfully executed down to the smallest details, Primary ran away with first place. — **O_O 2021 Judges**
 
-# 🚧 Primary is currently undergoing a 2.0 Rebuild 
+# 🚧 Primary is currently undergoing a 2.0 Rebuild
 
-This README is underconstruction. Everything below is outdated, and does not reflect it's current status. Please be advised. 
+This README is underconstruction. Everything below is outdated, and does not reflect it's current status. Please be advised.
 
-Though, I am currently rebuilding it to support Obsidian 1.0+. To support Primary's 2.0 Rebuild (available April 2024 onwards), the beta is currently available to [Monthly Subscribers](https://dub.sh/primary/ko-fi)! New beta versions are released weekly.
+Though, I am currently rebuilding it to support Obsidian 1.0+. To support Primary's 2.0 Rebuild (available April 2024 onwards), the beta is currently available to [Monthly Subscribers](https://ko-fi.com/ceciliamay)! New beta versions are released weekly.
 
-All new updates can be seen through [Twitter](https://dub.sh/twitter/mei).
+All new updates can be seen through [Twitter](https://x.com/ceciliamay_).
 
 ---
 
@@ -104,7 +104,7 @@ By downloading the Style Settings plugin, Primary offers you tons of customizati
     - Custom Bold and Italics color
     - Custom Strikethrough color
     - Custom "Hidden Comments" `%% text %%` color
-    - Custom Resolved and Unresolved Links color 
+    - Custom Resolved and Unresolved Links color
     - Custom Blockquotes color (change text color, syntax color, border color, background color)
     - Custom Highlight colors
 - 3 Markdown Embed Style options (Original, Minimal, or Clean)

--- a/Primary.css
+++ b/Primary.css
@@ -29,12 +29,12 @@ GitHub : @ceciliamay
 Get ✦ P R I M A R Y ✦ updates right
 in your inbox 📮
 
-https://dub.sh/primary/inbox
+https://primarytheme.substack.com/subscribe
 
 ────────────────────────────────────
 
 ● SUPPORT MY WORK ●
-https://dub.sh/primary/ko-fi
+https://ko-fi.com/ceciliamay
 + early access to updates
 + Premium Palettes
 + ports to other theme-able Apps
@@ -61,7 +61,7 @@ CODE STRUCTURE
     4. Light Theme
     5. Dark Theme
 
-────────────────────────────────────      
+────────────────────────────────────
 
 This theme is using the
 GNU GENERAL PUBLIC LICENSE v3.
@@ -73,7 +73,7 @@ https://git.new/primary/obsidian
 If you will be using parts of the code
 or are inspired, please do leave a link
 to my Ko-fi:
-https://dub.sh/primary/ko-fi
+https://ko-fi.com/ceciliamay
 
 as well as leave a link to the original
 GitHub repository:
@@ -85,7 +85,7 @@ and visibly. Thank you so much!
 ────────────────────────────────────*/
 /*────────── Cascadia Code ──────────*/
 
-/* 
+/*
 Cascadia Code
     by Microsoft
     v2111.01 via GitHub
@@ -109,7 +109,7 @@ Option to turn it off via Style Settings
 is added.
 */
 
-@font-face { 
+@font-face {
     font-family: "Cascadia Code";
     /* font-feature-settings:
         "calt" on,
@@ -119,7 +119,7 @@ is added.
 }
 /*────────── Inter ──────────*/
 
-/* 
+/*
 Inter (Variable)
 Inter Italic (Variable)
     by Rasmus Andersson
@@ -153,7 +153,7 @@ is added.
 */
 
 /* Inter Variable */
-@font-face { 
+@font-face {
     font-family: "Inter";
     font-style: normal;
     font-weight: 100 900;
@@ -161,7 +161,7 @@ is added.
 }
 
 /* Inter Variable Italic */
-@font-face { 
+@font-face {
     font-family: "Inter";
     font-style: italic;
     font-weight: 100 900;
@@ -193,7 +193,7 @@ settings:
         id: readme-content
         type: info-text
         markdown: true
-        description: 📮 Subscribe to [Primary Theme Updates](https://dub.sh/primary/inbox) to get notified of Primary updates, new features, and goodies right in your inbox!
+        description: 📮 Subscribe to [Primary Theme Updates](https://primarytheme.substack.com/subscribe) to get notified of Primary updates, new features, and goodies right in your inbox!
 	-
 		id: interface
 		type: heading
@@ -2696,7 +2696,7 @@ settings:
         description: Color of notes that don't exist (unresolved backlinks)
         default-light: 'hsla(43, 83%, 57%, 1)'
         default-dark: 'hsla(42, 79%, 51%, 1)'
-    - 
+    -
         id: graph-node-unresolved-opacity
         type: variable-number
         title: Unresolved Note Node Opacity
@@ -2788,7 +2788,7 @@ settings:
         type: info-text
         markdown: true
         title: 💗 Make a Donation on Ko-fi
-        description: Support development by subscribing monthly or making a one-time donation at [Primary's Ko-fi Page](https://dub.sh/primary/ko-fi).
+        description: Support development by subscribing monthly or making a one-time donation at [Primary's Ko-fi Page](https://ko-fi.com/ceciliamay).
     -
         id: readme-content
         type: info-text
@@ -2800,5 +2800,5 @@ settings:
         type: info-text
         markdown: true
         title: 🐛 Submit an Issue or Feature Request!
-        description: Visit [Primary's Github Issue Page](https://git.new/primary/obsidian) to submit an issue or feature request. <br> No Github account? Send me a message through [Twitter](https://dub.sh/twitter/mei) or directly via [Email](mailto:contact.ceciliamay@gmail.com)
+        description: Visit [Primary's Github Issue Page](https://git.new/primary/obsidian) to submit an issue or feature request. <br> No Github account? Send me a message through [Twitter](https://x.com/ceciliamay_) or directly via [Email](mailto:contact.ceciliamay@gmail.com)
 */

--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@
 <small>
     This refresh wouldn't be possible without my <a href="https://github.com/primary-theme/obsidian/releases/tag/v.2.7.0">supporters</a>!
     <br><br>
-    If you like the theme, consider supporting its development by making a one-time donation or subscribe monthly (with perks!) through <a href="https://dub.sh/primary/ko-fi">Ko-fi</a>.
+    If you like the theme, consider supporting its development by making a one-time donation or subscribe monthly (with perks!) through <a href="https://ko-fi.com/ceciliamay">Ko-fi</a>.
     <br><br>
     Thank you so much for your patronage!
     <br><br>
 </small>
-  
+
 <p align="center">
     <a href='https://ko-fi.com/E1E76SQX8' target='_blank'><img height='36' style='border:0px;height:36px;' src='https://storage.ko-fi.com/cdn/kofi1.png?v=3' border='0' alt='Buy Me a Coffee at ko-fi.com' /></a>
 </p>
@@ -115,7 +115,7 @@ Primary is an opinionated Obsidian theme that merges play with work.
 
 Fine-tuned to pixel and color perfection, Primary aims to take away the need to think about customization, so that you can focus on what matters – the concepts, that link, this great idea.
 
-Despite being opinionated, it has plenty of options and ways to make it yours. 
+Despite being opinionated, it has plenty of options and ways to make it yours.
 
 Stay tuned, because Primary will come in more flavors soon.
 
@@ -178,7 +178,7 @@ This option will give you access to public releases.
 
 This option is exclusive to monthly subscribers of Primary.
 
-1. Head on over to [Primary's Ko-fi](https://dub.sh/primary/ko-fi) page.Under Buy a Coffee, choose Membership and subscribe to get access to member exclusive posts.
+1. Head on over to [Primary's Ko-fi](https://ko-fi.com/ceciliamay) page.Under Buy a Coffee, choose Membership and subscribe to get access to member exclusive posts.
 2. After subscribing, head over to the `Posts` tab. This is under the header, just below my name and ko-fi link.
 3. Once in the Posts tab, you should be able to find posts usually titled along the lines of `Primary x.x.x-beta (Monthly Subscriber Exclusive)`. Click on the latest post.
 4. The post includes the full Release Notes so you're fully informed what new features or fixes you get for that release! To get the a copy of that beta, scroll down a bit until you find the `Click here to download the CSS file.` link. This should take you to a GitHub gist page.
@@ -217,7 +217,7 @@ Another great way to contribute is by sharing screenshots of how you use Primary
 
 Let's start by installing the essentials.
 
-Primary is written with a mix of CSS and [Sass](https://sass-lang.com/guide/). If you haven't, do install Sass. 
+Primary is written with a mix of CSS and [Sass](https://sass-lang.com/guide/). If you haven't, do install Sass.
 
 ```
 sudo gem install sass

--- a/manifest.json
+++ b/manifest.json
@@ -4,6 +4,6 @@
   "minAppVersion": "1.4.0",
   "author": "Cecilia May",
   "fundingUrl": {
-    "Ko-fi": "https://dub.sh/primary/ko-fi"
+    "Ko-fi": "https://ko-fi.com/ceciliamay"
   }
 }

--- a/src/css/readme.css
+++ b/src/css/readme.css
@@ -29,12 +29,12 @@ GitHub : @ceciliamay
 Get ✦ P R I M A R Y ✦ updates right
 in your inbox 📮
 
-https://dub.sh/primary/inbox
+https://primarytheme.substack.com/subscribe
 
 ────────────────────────────────────
 
 ● SUPPORT MY WORK ●
-https://dub.sh/primary/ko-fi
+https://ko-fi.com/ceciliamay
 + early access to updates
 + Premium Palettes
 + ports to other theme-able Apps
@@ -61,7 +61,7 @@ CODE STRUCTURE
     4. Light Theme
     5. Dark Theme
 
-────────────────────────────────────      
+────────────────────────────────────
 
 This theme is using the
 GNU GENERAL PUBLIC LICENSE v3.
@@ -73,7 +73,7 @@ https://git.new/primary/obsidian
 If you will be using parts of the code
 or are inspired, please do leave a link
 to my Ko-fi:
-https://dub.sh/primary/ko-fi
+https://ko-fi.com/ceciliamay
 
 as well as leave a link to the original
 GitHub repository:

--- a/src/css/style-settings.css
+++ b/src/css/style-settings.css
@@ -23,7 +23,7 @@ settings:
         id: readme-content
         type: info-text
         markdown: true
-        description: 📮 Subscribe to [Primary Theme Updates](https://dub.sh/primary/inbox) to get notified of Primary updates, new features, and goodies right in your inbox!
+        description: 📮 Subscribe to [Primary Theme Updates](https://primarytheme.substack.com/subscribe) to get notified of Primary updates, new features, and goodies right in your inbox!
 	-
 		id: interface
 		type: heading
@@ -2526,7 +2526,7 @@ settings:
         description: Color of notes that don't exist (unresolved backlinks)
         default-light: 'hsla(43, 83%, 57%, 1)'
         default-dark: 'hsla(42, 79%, 51%, 1)'
-    - 
+    -
         id: graph-node-unresolved-opacity
         type: variable-number
         title: Unresolved Note Node Opacity
@@ -2618,7 +2618,7 @@ settings:
         type: info-text
         markdown: true
         title: 💗 Make a Donation on Ko-fi
-        description: Support development by subscribing monthly or making a one-time donation at [Primary's Ko-fi Page](https://dub.sh/primary/ko-fi).
+        description: Support development by subscribing monthly or making a one-time donation at [Primary's Ko-fi Page](https://ko-fi.com/ceciliamay).
     -
         id: readme-content
         type: info-text
@@ -2630,5 +2630,5 @@ settings:
         type: info-text
         markdown: true
         title: 🐛 Submit an Issue or Feature Request!
-        description: Visit [Primary's Github Issue Page](https://git.new/primary/obsidian) to submit an issue or feature request. <br> No Github account? Send me a message through [Twitter](https://dub.sh/twitter/mei) or directly via [Email](mailto:contact.ceciliamay@gmail.com)
+        description: Visit [Primary's Github Issue Page](https://git.new/primary/obsidian) to submit an issue or feature request. <br> No Github account? Send me a message through [Twitter](https://x.com/ceciliamay_) or directly via [Email](mailto:contact.ceciliamay@gmail.com)
 */

--- a/theme.css
+++ b/theme.css
@@ -29,12 +29,12 @@ GitHub : @ceciliamay
 Get ✦ P R I M A R Y ✦ updates right
 in your inbox 📮
 
-https://dub.sh/primary/inbox
+https://primarytheme.substack.com/subscribe
 
 ────────────────────────────────────
 
 ● SUPPORT MY WORK ●
-https://dub.sh/primary/ko-fi
+https://ko-fi.com/ceciliamay
 + early access to updates
 + Premium Palettes
 + ports to other theme-able Apps
@@ -61,7 +61,7 @@ CODE STRUCTURE
     4. Light Theme
     5. Dark Theme
 
-────────────────────────────────────      
+────────────────────────────────────
 
 This theme is using the
 GNU GENERAL PUBLIC LICENSE v3.
@@ -73,7 +73,7 @@ https://git.new/primary/obsidian
 If you will be using parts of the code
 or are inspired, please do leave a link
 to my Ko-fi:
-https://dub.sh/primary/ko-fi
+https://ko-fi.com/ceciliamay
 
 as well as leave a link to the original
 GitHub repository:
@@ -85,7 +85,7 @@ and visibly. Thank you so much!
 ────────────────────────────────────*/
 /*────────── Cascadia Code ──────────*/
 
-/* 
+/*
 Cascadia Code
     by Microsoft
     v2111.01 via GitHub
@@ -109,7 +109,7 @@ Option to turn it off via Style Settings
 is added.
 */
 
-@font-face { 
+@font-face {
     font-family: "Cascadia Code";
     /* font-feature-settings:
         "calt" on,
@@ -119,7 +119,7 @@ is added.
 }
 /*────────── Inter ──────────*/
 
-/* 
+/*
 Inter (Variable)
 Inter Italic (Variable)
     by Rasmus Andersson
@@ -153,7 +153,7 @@ is added.
 */
 
 /* Inter Variable */
-@font-face { 
+@font-face {
     font-family: "Inter";
     font-style: normal;
     font-weight: 100 900;
@@ -161,7 +161,7 @@ is added.
 }
 
 /* Inter Variable Italic */
-@font-face { 
+@font-face {
     font-family: "Inter";
     font-style: italic;
     font-weight: 100 900;
@@ -193,7 +193,7 @@ settings:
         id: readme-content
         type: info-text
         markdown: true
-        description: 📮 Subscribe to [Primary Theme Updates](https://dub.sh/primary/inbox) to get notified of Primary updates, new features, and goodies right in your inbox!
+        description: 📮 Subscribe to [Primary Theme Updates](https://primarytheme.substack.com/subscribe) to get notified of Primary updates, new features, and goodies right in your inbox!
 	-
 		id: interface
 		type: heading
@@ -2696,7 +2696,7 @@ settings:
         description: Color of notes that don't exist (unresolved backlinks)
         default-light: 'hsla(43, 83%, 57%, 1)'
         default-dark: 'hsla(42, 79%, 51%, 1)'
-    - 
+    -
         id: graph-node-unresolved-opacity
         type: variable-number
         title: Unresolved Note Node Opacity
@@ -2788,7 +2788,7 @@ settings:
         type: info-text
         markdown: true
         title: 💗 Make a Donation on Ko-fi
-        description: Support development by subscribing monthly or making a one-time donation at [Primary's Ko-fi Page](https://dub.sh/primary/ko-fi).
+        description: Support development by subscribing monthly or making a one-time donation at [Primary's Ko-fi Page](https://ko-fi.com/ceciliamay).
     -
         id: readme-content
         type: info-text
@@ -2800,5 +2800,5 @@ settings:
         type: info-text
         markdown: true
         title: 🐛 Submit an Issue or Feature Request!
-        description: Visit [Primary's Github Issue Page](https://git.new/primary/obsidian) to submit an issue or feature request. <br> No Github account? Send me a message through [Twitter](https://dub.sh/twitter/mei) or directly via [Email](mailto:contact.ceciliamay@gmail.com)
+        description: Visit [Primary's Github Issue Page](https://git.new/primary/obsidian) to submit an issue or feature request. <br> No Github account? Send me a message through [Twitter](https://x.com/ceciliamay_) or directly via [Email](mailto:contact.ceciliamay@gmail.com)
 */


### PR DESCRIPTION
# 📕 Description

Their certificate is invalid. In general it might be better to use direct links, but if you really want to have some tracking or whatever dub.sh is providing (their website isn't loading because of the certificate issue so I can't tell what they do 😂) maybe chose something with better credibility? 😬 

While at it: Maybe replace _Twitter_ with _X_?

Fixes # (issue)

**What is the current behavior?**

![CleanShot 2024-08-19 at 10 25 34@2x](https://github.com/user-attachments/assets/61a30391-1723-4ad9-a7af-426fcf0565b7)


**What is the new behavior?**

Direct links

**Other Information or Things to be taken Note of**


## 🔖 Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# ✅ Checklist

All checkboxes below must be followed and checked.

- [ ] I followed the **Developer's Guide** when building for Primary

Primary uses Sass and Grunt so building the project is important to ensure the final production code is up to date with changes from all the `.scss` and `.css` files. If you are unsure about this please look into the Developer's section inside the README or if you have any questions, post an issue or send us a message before sending in this Pull Request.

- [ ] My code follows the style guidelines of Primary
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings