### PR TITLE
Fix --callout-color for Obsidian 1.13+

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,9 @@
 {
-  "name": "Primary",
-  "version": "2.10.0",
-  "minAppVersion": "1.4.0",
-  "author": "Cecilia May",
-  "fundingUrl": {
-    "Ko-fi": "https://ko-fi.com/ceciliamay"
-  }
+    "name": "Primary",
+    "version": "2.10.0",
+    "minAppVersion": "1.13.0",
+    "author": "Cecilia May",
+    "fundingUrl": {
+        "Ko-fi": "https://ko-fi.com/ceciliamay"
+    }
 }

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -5193,7 +5193,7 @@ li.task-list-item[data-task="-"] {
 }
 
 .callout {
-  background-color: color-mix(in srgb, rgba(var(--callout-color)) var(--callout-color-opacity), var(--editor-bg-color));
+  background-color: color-mix(in srgb, var(--callout-color) var(--callout-color-opacity), var(--editor-bg-color));
   padding: 0;
   box-shadow: var(--callout-container-shadow);
 }
@@ -5258,33 +5258,33 @@ body {
   --callout-icon-example: scroll-text;
   --callout-icon-quote: message-square-note;
   --callout-icon-cite: book-marked;
-  --callout-rgb-general: 182, 196, 182;
-  --callout-rgb-note: 200, 175, 155;
-  --callout-rgb-summary: 234, 181, 52;
-  --callout-rgb-abstract: 34, 152, 225;
-  --callout-rgb-tldr: 240, 180, 225;
-  --callout-rgb-info: 71, 162, 187;
-  --callout-rgb-todo: 58, 173, 252;
-  --callout-rgb-tip: 70, 206, 185;
-  --callout-rgb-hint: 70, 206, 185;
-  --callout-rgb-important: 246, 113, 118;
-  --callout-rgb-success: 87, 200, 83;
-  --callout-rgb-check: 87, 200, 83;
-  --callout-rgb-done: 87, 200, 83;
-  --callout-rgb-question: 130, 190, 235;
-  --callout-rgb-help: 250, 128, 96;
-  --callout-rgb-faq: 130, 190, 235;
-  --callout-rgb-warning: 255, 161, 32;
-  --callout-rgb-caution: 255, 161, 32;
-  --callout-rgb-attention: 255, 161, 32;
-  --callout-rgb-fail: 226, 72, 86;
-  --callout-rgb-missing: 226, 72, 86;
-  --callout-rgb-danger: 226, 72, 86;
-  --callout-rgb-error: 226, 72, 86;
-  --callout-rgb-bug: 153, 93, 133;
-  --callout-rgb-example: 216, 141, 130;
-  --callout-rgb-quote: 173, 214, 171;
-  --callout-rgb-cite: 237, 217, 162;
+  --callout-rgb-general: rgb(182, 196, 182);
+  --callout-rgb-note: rgb(200, 175, 155);
+  --callout-rgb-summary: rgb(234, 181, 52);
+  --callout-rgb-abstract: rgb(34, 152, 225);
+  --callout-rgb-tldr: rgb(240, 180, 225);
+  --callout-rgb-info: rgb(71, 162, 187);
+  --callout-rgb-todo: rgb(58, 173, 252);
+  --callout-rgb-tip: rgb(70, 206, 185);
+  --callout-rgb-hint: rgb(70, 206, 185);
+  --callout-rgb-important: rgb(246, 113, 118);
+  --callout-rgb-success: rgb(87, 200, 83);
+  --callout-rgb-check: rgb(87, 200, 83);
+  --callout-rgb-done: rgb(87, 200, 83);
+  --callout-rgb-question: rgb(130, 190, 235);
+  --callout-rgb-help: rgb(250, 128, 96);
+  --callout-rgb-faq: rgb(130, 190, 235);
+  --callout-rgb-warning: rgb(255, 161, 32);
+  --callout-rgb-caution: rgb(255, 161, 32);
+  --callout-rgb-attention: rgb(255, 161, 32);
+  --callout-rgb-fail: rgb(226, 72, 86);
+  --callout-rgb-missing: rgb(226, 72, 86);
+  --callout-rgb-danger: rgb(226, 72, 86);
+  --callout-rgb-error: rgb(226, 72, 86);
+  --callout-rgb-bug: rgb(153, 93, 133);
+  --callout-rgb-example: rgb(216, 141, 130);
+  --callout-rgb-quote: rgb(173, 214, 171);
+  --callout-rgb-cite: rgb(237, 217, 162);
 }
 
 .callout {

--- a/src/scss/40_editor/_callout.scss
+++ b/src/scss/40_editor/_callout.scss
@@ -11,7 +11,7 @@
 .callout {
     background-color: color-mix(
                             in srgb,
-                            rgba(var(--callout-color)) var(--callout-color-opacity), 
+                            var(--callout-color) var(--callout-color-opacity), 
                             var(--editor-bg-color)
                             );
     padding: 0;
@@ -100,33 +100,33 @@ body {
     --callout-icon-cite: book-marked;
 
     // Native Callout Colors
-    --callout-rgb-general: 182, 196, 182;
-    --callout-rgb-note: 200, 175, 155;
-    --callout-rgb-summary: 234, 181, 52;
-    --callout-rgb-abstract: 34, 152, 225;
-    --callout-rgb-tldr: 240, 180, 225;
-    --callout-rgb-info: 71, 162, 187;
-    --callout-rgb-todo: 58, 173, 252;
-    --callout-rgb-tip: 70, 206, 185;
-    --callout-rgb-hint: 70, 206, 185;
-    --callout-rgb-important: 246, 113, 118;
-    --callout-rgb-success: 87, 200, 83;
-    --callout-rgb-check: 87, 200, 83;
-    --callout-rgb-done: 87, 200, 83;
-    --callout-rgb-question: 130, 190, 235;
-    --callout-rgb-help: 250, 128, 96;
-    --callout-rgb-faq: 130, 190, 235;
-    --callout-rgb-warning: 255, 161, 32;
-    --callout-rgb-caution: 255, 161, 32;
-    --callout-rgb-attention: 255, 161, 32;
-    --callout-rgb-fail: 226, 72, 86;
-    --callout-rgb-missing: 226, 72, 86;
-    --callout-rgb-danger: 226, 72, 86;
-    --callout-rgb-error: 226, 72, 86;
-    --callout-rgb-bug: 153, 93, 133;
-    --callout-rgb-example: 216, 141, 130;
-    --callout-rgb-quote: 173, 214, 171;
-    --callout-rgb-cite: 237, 217, 162;
+    --callout-rgb-general: rgb(182, 196, 182);
+    --callout-rgb-note: rgb(200, 175, 155);
+    --callout-rgb-summary: rgb(234, 181, 52);
+    --callout-rgb-abstract: rgb(34, 152, 225);
+    --callout-rgb-tldr: rgb(240, 180, 225);
+    --callout-rgb-info: rgb(71, 162, 187);
+    --callout-rgb-todo: rgb(58, 173, 252);
+    --callout-rgb-tip: rgb(70, 206, 185);
+    --callout-rgb-hint: rgb(70, 206, 185);
+    --callout-rgb-important: rgb(246, 113, 118);
+    --callout-rgb-success: rgb(87, 200, 83);
+    --callout-rgb-check: rgb(87, 200, 83);
+    --callout-rgb-done: rgb(87, 200, 83);
+    --callout-rgb-question: rgb(130, 190, 235);
+    --callout-rgb-help: rgb(250, 128, 96);
+    --callout-rgb-faq: rgb(130, 190, 235);
+    --callout-rgb-warning: rgb(255, 161, 32);
+    --callout-rgb-caution: rgb(255, 161, 32);
+    --callout-rgb-attention: rgb(255, 161, 32);
+    --callout-rgb-fail: rgb(226, 72, 86);
+    --callout-rgb-missing: rgb(226, 72, 86);
+    --callout-rgb-danger: rgb(226, 72, 86);
+    --callout-rgb-error: rgb(226, 72, 86);
+    --callout-rgb-bug: rgb(153, 93, 133);
+    --callout-rgb-example: rgb(216, 141, 130);
+    --callout-rgb-quote: rgb(173, 214, 171);
+    --callout-rgb-cite: rgb(237, 217, 162);
 }
 
 .callout {


### PR DESCRIPTION
Hello! I'm [saberzero1](https://github.com/saberzero1), a [community reviewer](https://obsidian.md/help/credits#Community+review) for Obsidian plugins and themes. We're sending this PR out to you proactively to help you prepare for a recent Obsidian update.

## Summary

Obsidian 1.13 changed how `--callout-color` works. It now provides a valid CSS color value (e.g. `rgb(255, 0, 128)`) instead of a bare RGB triplet (`255, 0, 128`).

This breaks two patterns:

**1. Bare RGB triplets in declarations:**
```css
/* Before (broken on 1.13+) */
--callout-color: 255, 0, 128;
/* After */
--callout-color: rgb(255, 0, 128);
```

**2. Wrapping `var(--callout-color)` in `rgb()`/`rgba()`:**
```css
/* Before (produces invalid rgb(rgb(...)) on 1.13+) */
background: rgba(var(--callout-color), 0.1);
/* After */
background: color-mix(in srgb, var(--callout-color) 10%, transparent);
```

## Changes

- Wrapped bare RGB triplets in `--callout-color` declarations with `rgb()`
- Replaced `rgb(var(--callout-color))` with `var(--callout-color)`
- Replaced `rgba(var(--callout-color), <alpha>)` with `color-mix(in srgb, var(--callout-color) <percent>, transparent)`
- Updated `minAppVersion` in `manifest.json` to `1.13.0` (if it was lower)

## Context

See the [Obsidian 1.13 changelog](https://obsidian.md/changelog/) for details on this breaking change.
